### PR TITLE
Update To Use Official SushiSwap Subgraph

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
 .DS_Store
+
+node_modules
+
+browser.js

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@
 const pageResults = require('graph-results-pager');
 
 const graphAPIEndpoints = {
-	masterchef: 'https://api.thegraph.com/subgraphs/name/zippoxer/sushiswap',
+	masterchef: 'https://api.thegraph.com/subgraphs/name/sushiswap/sushiswap',
 };
 
 module.exports = {
@@ -22,21 +22,22 @@ module.exports = {
 						'allocPoint',
 						'lastRewardBlock',
 						'accSushiPerShare',
-						'exchange',
-						'addedAt',
+						'addedBlock',
+						'addedTs',
 					],
 				},
 			})
 				.then(results =>
-					results.map(({ id, balance, lpToken, allocPoint, lastRewardBlock, accSushiPerShare, exchange, addedAt }) => ({
+					results.map(({ id, balance, lpToken, allocPoint, lastRewardBlock, accSushiPerShare, addedBlock, addedTs }) => ({
 						id: Number(id),
-						balance: Number(balance),
+						balance: balance / 1e18,
 						lpToken: lpToken,
 						allocPoint: Number(allocPoint),
 						lastRewardBlock: Number(lastRewardBlock),
-						accSushiPerShare: Number(accSushiPerShare),
-						exchange: exchange,
-						addedAt: addedAt,
+						accSushiPerShare: accSushiPerShare / 1e18,
+						addedBlock: Number(addedBlock),
+						addedTs: Number(addedTs * 1000),
+						date: new Date(addedTs * 1000)
 					})),
 				)
 				.catch(err => console.log(err));

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@sushiswap/sushi-data",
 	"license": "MIT",
-	"version": "0.0.1",
+	"version": "0.0.2",
 	"author": "SushiSwap",
 	"main": "index.js",
 	"scripts": {


### PR DESCRIPTION
Switched to use this url: `https://thegraph.com/explorer/subgraph/sushiswap/sushiswap`

Also updated the scheme to match what the subgraph outputs now.