### PR TITLE
Add Additional Queries to Help With APY Calculation

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,16 +7,19 @@ data has been indexed by the Graph via the subgraph the SushiSwap team maintains
 
 The below all return a Promise that resolves with the requested results.
 
-1. `masterchef.Info()` Get MasterChef Contract Info.
-2. `masterchef.Pools()` Get all pool info for pools in MasterChef.
-3. `masterchef.TimeLocks()` Get all queued TimLock Txs. ** Will be removed soon **
-4. `timelock.Txs()` Get all queued/executed/canceled Timelock txs.
-5. `bar.Info()` Get all SushiBar contract info.
-6. `bar.User({ user: "address"})` Get sushi bar data for specific address.
-7. `maker.Info()` Get SushiMaker contract info
-8. `maker.Servings()` Get all past servings to the bar.
-9. `maker.Servers()` Get all addresses that have served sushi to the bar.
-10. `maker.PendingServings()` Get all data on all of the servings that are ready to be served to the bar.
+1. `weth.price()` Gets current USDC price of WETH.
+2. `sushi.info()` Get sushi ETH price and total supply.
+3. `masterchef.info()` Get MasterChef Contract Info.
+4. `masterchef.pools()` Get all pool info for pools in MasterChef.
+5. `masterchef.pool()` Get pool info for a single pool in MasterChef.
+6. `masterchef.stakedValue()` Get pricing info for MasterChef pools
+7. `timelock.txs()` Get all queued/executed/canceled Timelock txs.
+8. `bar.info()` Get all SushiBar contract info.
+9. `bar.user({ user: "address"})` Get sushi bar data for specific address.
+10. `maker.info()` Get SushiMaker contract info
+11. `maker.servings()` Get all past servings to the bar.
+12. `maker.servers()` Get all addresses that have served sushi to the bar.
+13. `maker.pendingServings()` Get all data on all of the servings that are ready to be served to the bar.
 
 ## Example
 

--- a/index.js
+++ b/index.js
@@ -91,7 +91,8 @@ module.exports = {
 				)
 				.catch(err => console.log(err));
 		},
-
+		// TODO: probably better to have a way for this to return pool info with either
+		//       ID or tokenAddress. Or just decide which is better to use.
 		pools() {
 			return pageResults({
 				api: graphAPIEndpoints.masterchef,
@@ -151,7 +152,7 @@ module.exports = {
 			})
 				.then(results =>
 					results.map(({ id, balance, lpToken, allocPoint, lastRewardBlock, accSushiPerShare, addedBlock, addedTs }) => ({
-						id: id,
+						id: Number(id),
 						balance: balance / 1e18,
 						lpToken: lpToken,
 						allocPoint: Number(allocPoint),
@@ -164,9 +165,6 @@ module.exports = {
 				)
 				.catch(err => console.log(err));
 		},
-		// TODO: this technically isn't completely right, it returns the balance
-		//       staked in the exchange regardless if in masterchef or not.
-		//       would rather this return values in masterChef
 		stakedValue({ lpToken = undefined }) {
 			let chef_address = "0xc2edad668740f1aa35e4d8f227fb8e17dca888cd"
 			return pageResults({
@@ -187,6 +185,8 @@ module.exports = {
 			})
 				.then(results =>
 					results.map(({ id, liquidityTokenBalance, pair }) => ({
+						// TODO: I don't think all of this info is necessary, we can get away
+						//       with just returning totalValueETH and totalValueUSD for this query
 						id: id,
 						liquidityTokenBalance: Number(liquidityTokenBalance),
 						totalSupply: Number(pair.totalSupply),
@@ -469,5 +469,5 @@ module.exports = {
 				.catch(err => console.log(err));
 		}
 	},
-	
+
 };

--- a/index.js
+++ b/index.js
@@ -14,8 +14,59 @@ const graphAPIEndpoints = {
 module.exports = {
 	pageResults,
 	graphAPIEndpoints,
+	weth: {
+		price() {
+			let weth_usdc_pair = "0x397ff1542f962076d0bfe58ea045ffa2d347aca0"
+			return pageResults({
+				api: graphAPIEndpoints.exchange,
+				query: {
+					entity: 'pairs',
+					selection: {
+						where: {
+							id: `\\"${weth_usdc_pair}\\"`
+						}
+					},
+					properties: [
+						'token0Price'
+					]
+				}
+			})
+				.then(([{ token0Price }]) => (Number(token0Price)))
+				.catch(err => console.error(err))
+		}
+	},
+	// TODO: can add blockNumber as another parameter to this to get the price for any block
+	sushi: {
+		info() {
+			let sushi_address = "0x6b3595068778dd592e39a122f4f5a5cf09c90fe2"
+			return pageResults({
+				api: graphAPIEndpoints.exchange,
+				query: {
+					entity: 'tokens',
+					selection: {
+						where: {
+							id: `\\"${sushi_address}\\"`
+						}
+					},
+					properties: [
+						'derivedETH',
+						'totalSupply'
+					]
+				}
+			})
+				// TODO: need to figure out to not return this is an arraay, rather just an object
+				.then(results =>
+					results.map(({ derivedETH, totalSupply }) => ({
+						derivedETH: Number(derivedETH),
+						totalSupply: Number(totalSupply)
+					}))
+				)
+				.catch(err => console.log(err));
+		}
+	},
+
 	masterchef: {
-		Info() {
+		info() {
 			return pageResults({
 				api: graphAPIEndpoints.masterchef,
 				// Note: a single subgraph fetch can return 1000 results, any larger numbers will trigger multiple fetches
@@ -41,7 +92,7 @@ module.exports = {
 				.catch(err => console.log(err));
 		},
 
-		Pools() {
+		pools() {
 			return pageResults({
 				api: graphAPIEndpoints.masterchef,
 				query: {
@@ -74,70 +125,81 @@ module.exports = {
 				.catch(err => console.log(err));
 		},
 
-		TimeLocks() {
+		pool({ poolId = undefined }) {
+			// TODO: poolId must be a string, otherwise returns all of the pools if Num. Need to figure out how to support both types.
+			//       can also probably get rid of pools() above and just use the query to return both individual pools and all pools
 			return pageResults({
 				api: graphAPIEndpoints.masterchef,
 				query: {
-					entity: 'timelocks',
+					entity: 'masterChefPools',
 					selection: {
-						orderBy: 'createdBlock',
-						orderDirection: 'desc',
+						where: {
+							id: poolId ? `\\"${poolId}\\"` : undefined
+						}
 					},
 					properties: [
 						'id',
-						'value',
-						'eta',
-						'functionName',
-						'data',
-						'targetAddress',
-						'isCanceled',
-						'isExecuted',
-						'createdBlock',
-						'createdTs',
-						'expiresTs',
-						'canceledBlock',
-						'canceledTs',
-						'executedBlock',
-						'executedTs',
-						'createdTx',
-						'canceledTx',
-						'executedTx'
-					],
-				},
+						'balance',
+						'lpToken',
+						'allocPoint',
+						'lastRewardBlock',
+						'accSushiPerShare',
+						'addedBlock',
+						'addedTs'
+					]
+				}
 			})
 				.then(results =>
-					results.map(({ id, value, eta, functionName, data, targetAddress, isCanceled, isExecuted, createdBlock, createdTs, expiresTs, canceledBlock, canceledTs, executedBlock, executedTs, createdTx, canceledTx, executedTx }) => ({
-						txHash: id,
-						value: Number(value),
-						etaTs: Number(eta * 1000),
-						etaDate: new Date(eta * 1000),
-						functionName: functionName,
-						data: data,
-						targetAddress: targetAddress,
-						isCanceled: isCanceled,
-						isExecuted: isExecuted,
-						createdBlock: Number(createdBlock),
-						createdTs: Number(createdTs * 1000),
-						createdDate: new Date(createdTs * 1000),
-						expiresTs: Number(expiresTs * 1000),
-						expiresDate: new Date(expiresTs * 1000),
-						canceledBlock: Number(canceledBlock),
-						canceledTs: Number(canceledTs * 1000),
-						canceledDate: new Date(canceledTs * 1000),
-						executedBlock: Number(executedBlock),
-						executedTs: Number(executedTs * 1000),
-						executedDate: new Date(executedTs * 1000),
-						createdTx: createdTx,
-						canceledTx: canceledTx,
-						executedTx: executedTx
-					})),
+					results.map(({ id, balance, lpToken, allocPoint, lastRewardBlock, accSushiPerShare, addedBlock, addedTs }) => ({
+						id: id,
+						balance: balance / 1e18,
+						lpToken: lpToken,
+						allocPoint: Number(allocPoint),
+						lastRewardBlock: Number(lastRewardBlock),
+						accSushiPerShare: accSushiPerShare / 1e18,
+						addedBlock: Number(addedBlock),
+						addedTs: Number(addedTs * 1000),
+						addedDate: new Date(addedTs * 1000)
+					}))
 				)
 				.catch(err => console.log(err));
 		},
-
+		// TODO: this technically isn't completely right, it returns the balance
+		//       staked in the exchange regardless if in masterchef or not.
+		//       would rather this return values in masterChef
+		stakedValue({ lpToken = undefined }) {
+			let chef_address = "0xc2edad668740f1aa35e4d8f227fb8e17dca888cd"
+			return pageResults({
+				api: graphAPIEndpoints.exchange,
+				query: {
+					entity: 'liquidityPositions',
+					selection: {
+						where: {
+							id: `\\"${lpToken.toLowerCase()}-${chef_address}\\"`
+						}
+					},
+					properties: [
+						'id',
+						'liquidityTokenBalance',
+						'pair { id, totalSupply, reserveETH, reserveUSD }'
+					]
+				}
+			})
+				.then(results =>
+					results.map(({ id, liquidityTokenBalance, pair }) => ({
+						id: id,
+						liquidityTokenBalance: Number(liquidityTokenBalance),
+						totalSupply: Number(pair.totalSupply),
+						totalValueETH: Number(pair.reserveETH),
+						totalValueUSD: Number(pair.reserveUSD)
+					}))
+				)
+				.catch(err => console.log(err))
+		}
 	},
+
 	bar: {
-		Info() {
+		info() {
 			return pageResults({
 				api: graphAPIEndpoints.bar,
 				query: {
@@ -183,7 +245,7 @@ module.exports = {
 				.catch(err => console.log(err));
 		},
 
-		User({ user = undefined }) {
+		user({ user = undefined }) {
 			return pageResults({
 				api: graphAPIEndpoints.bar,
 				query: {
@@ -229,8 +291,9 @@ module.exports = {
 		},
 
 	},
+
 	maker: {
-		Info() {
+		info() {
 			return pageResults({
 				api: graphAPIEndpoints.maker,
 				query: {
@@ -250,7 +313,7 @@ module.exports = {
 				.catch(err => console.log(err));
 		},
 
-		Servings() {
+		servings() {
 			return pageResults({
 				api: graphAPIEndpoints.maker,
 				query: {
@@ -288,7 +351,7 @@ module.exports = {
 		},
 
 		// TODO: Add support for getting Server's history of Servings here
-		Servers() {
+		servers() {
 			return pageResults({
 				api: graphAPIEndpoints.maker,
 				query: {
@@ -312,8 +375,8 @@ module.exports = {
 				.catch(err => console.log(err));
 		},
 
-		PendingServings(maker_address = "0x6684977bbed67e101bb80fc07fccfba655c0a64f") {
-			console.log(maker_address)
+		pendingServings() {
+			let maker_address = "0x6684977bbed67e101bb80fc07fccfba655c0a64f"
 			return pageResults({
 				api: graphAPIEndpoints.exchange,
 				query: {
@@ -341,9 +404,10 @@ module.exports = {
 				.catch(err => console.log(err));
 		}
 	},
+
 	timelock: {
 		// TODO: We can probably split this up into QueuedTxs, CanceledTxs, and ExecutedTxs
-		Txs() {
+		txs() {
 			return pageResults({
 				api: graphAPIEndpoints.timelock,
 				query: {
@@ -405,4 +469,5 @@ module.exports = {
 				.catch(err => console.log(err));
 		}
 	},
+	
 };

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@sushiswap/sushi-data",
 	"license": "MIT",
-	"version": "0.0.5",
+	"version": "0.0.6",
 	"author": "SushiSwap",
 	"main": "index.js",
 	"scripts": {


### PR DESCRIPTION
+ Adding additional queries that can be used for APY calculations.

+ Also add pricing for WETH and SUSHI in ETH that can be queried now.

# To calculate APY
*Note this is kind of a quick  n dirty implementation to get APY, and we will need to update once new subgraphs are deployed for exchange and masterchef.*

First you will need hardcode these values
+ `blocksPerDay`, I usually use 6500
+ `sushiPerBlock`, which is 80 as of now. **Due to change Dec 1st**

Then using sushi-data you can get the rest of the data like so:

+`sushiData.sushi.info()`: to get `derivedETH` price for SUSHI.
+`sushiData.masterchef.stakedValue({ lpToken: "<desired_pool_lpToken_address>" })` to get `totalValueETH` for desired pool.
+`sushiData.masterchef.pool({ poolId: "<desired_poolId>" })` to get `allocPoint` for desired pool.
+`sushiData.masterchef.info()` to get `totalAllocPoint` for all pools.


After retrieving all the data from the sushi-data queries you can calculate APY like so:

```javascript
// yearly APY Including 2/3rds Lockup
(derivedETH * blocksPerDay * sushiPerBlock * 3 * 365 * (allocPoint / totalAllocPoint)) / totalValueETH

// Not Including 2/3rds Lockup
(derivedETH * blocksPerDay * sushiPerBlock * 365 * (allocPoint / totalAllocPoint)) / totalValueETH

// to calculate APY for monthly replace 365 with 30
// to calculate APY for daily replace 365 with 1
```

**Not the cleanest way to calculate APY, but it should be much easier in the next iteration with the updates planned for masterchef and exchange subgraphs**
