### PR TITLE
Links NPM to github

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
 	"version": "1.0.26",
 	"author": "SushiSwap",
 	"main": "index",
+	"repository": "sushiswap/sushi-data",
 	"scripts": {
 		"lint": "eslint .",
 		"pack": "webpack --mode production",


### PR DESCRIPTION
Without this, there is no section on [the npm page](https://www.npmjs.com/package/@sushiswap/sushi-data) which links to GitHub. 

This helps with project legitimacy as folks who find this package via npm can now see the code associated. In addition, tools like `ghub` will now work to direct users to this github: https://ghub.io/@sushiswap/sushi-data